### PR TITLE
Add `nuget.config` file

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
This commit adds a `nuget.config` file pointing the .NET toolchain
to the regular Nuget server. I was not able to build the solution on
Windows without explicitly adding it.

