### PR TITLE
Fix CA1014 "Mark assemblies with CLSCompliant"

### DIFF
--- a/source/wagi/Helpers/WAGIHost.cs
+++ b/source/wagi/Helpers/WAGIHost.cs
@@ -1,4 +1,6 @@
-﻿namespace Deislabs.Wagi.Helpers
+﻿[assembly: System.CLSCompliant(false)]
+
+namespace Deislabs.Wagi.Helpers
 {
     using System;
     using System.Collections.Generic;


### PR DESCRIPTION
On some systems*, `dotnet build` gives `CSC : error CA1014: Mark assemblies with CLSCompliant [/.../source/wagi/wagi.csproj]`.  This PR provides the relevant attribute.

\* Okay, okay, on _my_ system and nobody else's.